### PR TITLE
fix: transforms on parameters that set bounds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8
@@ -14,7 +14,6 @@ repos:
     - id: flake8
       additional_dependencies:
         - flake8-docstrings
-        - flake8-black
         - flake8-builtins
         - flake8-logging-format
         - flake8-rst-docstrings
@@ -61,7 +60,7 @@ repos:
       args: [--py38-plus]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.20.3
+    rev: v2.21.2
     hooks:
     - id: commitizen
       stages: [commit-msg]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+v2.0.1
+------
+
+Fixed
+-----
+
+* Params with ``transforms`` now give the right bounds.
+
 v2.0.0 [25 Oct 2021]
 --------------------
 

--- a/src/yabf/core/component.py
+++ b/src/yabf/core/component.py
@@ -555,7 +555,6 @@ class ParameterComponent(_ComponentTree):
         Note that this is just the parameters themselves.
         """
         out = []
-
         for v in self.params:
             if len(v.determines) == 1:
                 out.append(v.new(self.base_parameter_dct[v.determines[0]]))

--- a/src/yabf/core/likelihood.py
+++ b/src/yabf/core/likelihood.py
@@ -197,7 +197,7 @@ class Likelihood(ParameterComponent, _LikelihoodInterface):
             raise TypeError(
                 "if using MPI and auto-generated mock data, data_seed must be set"
             )
-        return np.random.randint(0, 2 ** 32 - 1)
+        return np.random.randint(0, 2**32 - 1)
 
     @cached_property
     def _subcomponents(self):
@@ -542,6 +542,12 @@ class LikelihoodContainer(_LikelihoodInterface, _ComponentTree):
         logl = self.logl(model, ctx, params)  # this fills the params
         logprior = self.logprior(params)
         logger.info(f"logl: {logl}, prior: {logprior}")
+        if np.isnan(logl) or np.isinf(logl):
+            logger.warn(f"Got bad logl: {logl}, with params: {params}")
+        if np.isnan(logprior):
+            logger.warn(f"Got bad logprior: {logprior} with params: {params}")
+        if np.isinf(logprior):
+            logger.warn(f"prior out of bounds for params: {params}")
         return logl + logprior
 
     @cached_property

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -5,7 +5,7 @@ import pytest
 
 import attr
 import numpy as np
-from pypolychord import PolyChordOutput
+from pypolychord.output import PolyChordOutput
 from scipy import stats
 from scipy.integrate import quad, simps
 

--- a/tests/test_polychord.py
+++ b/tests/test_polychord.py
@@ -5,7 +5,7 @@ import pytest
 
 import attr
 import numpy as np
-from pypolychord import PolyChordOutput
+from pypolychord.output import PolyChordOutput
 from scipy import stats
 from scipy.integrate import quad, simps
 


### PR DESCRIPTION
Fixes a problem where basing a `Param` on a `Parameter` sets the wrong bounds if it has a transform.

