### PR TITLE
Support astropy loader

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+v2.2.0
+------
+
+Added
+-----
+
+* Ability to set the YAML loader when loading likelihoods from YAML. This can be done
+  programmatically or via CLI by using eg. ``--yaml-loader astropy.io.misc.AstropyLoader``
+
 v2.1.1
 ------
 

--- a/src/yabf/core/io.py
+++ b/src/yabf/core/io.py
@@ -39,6 +39,7 @@ def data_loader(tag=None):
             return wrapper(node.value)
 
         yaml.add_constructor(f"!{new_tag}", yaml_fnc, Loader=yaml.FullLoader)
+        yaml.add_constructor(f"!{new_tag}", yaml_fnc, Loader=yaml.SafeLoader)
         yaml.add_constructor(f"!{new_tag}", yaml_fnc, Loader=yaml.Loader)
 
         return wrapper


### PR DESCRIPTION
Support for arbitrary loaders to be specified. As long as they are subclasses of SafeLoader or FullLoader, all the custom YAML tags implemented by `yabf` itself will work. The astropy loader is a subclass of SafeLoader, so can now be used.