### PR TITLE
ci: better pypi deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,8 @@ jobs:
   build-n-publish:
     name: Make Release on PyPI and Github
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@master
         with:
@@ -15,16 +17,20 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version-file: .python-version
+          python-version-file: "pyproject.toml"
 
-      - name: Install Build Tools
-        run: pip install build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Build a binary wheel
         run: |
-          python -m build .
+          uv build
+
+      - name: Check Distribution
+        run: |
+          uvx twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary by Sourcery

Update the PyPI release workflow to use uv-based builds and modern PyPI publishing settings.

CI:
- Switch the deploy workflow to derive Python version from pyproject.toml and build distributions using uv.
- Add a distribution integrity check step using twine via uvx before publishing to PyPI.
- Update the PyPI publish action to the maintained release/v1 ref and configure OIDC id-token write permissions for the workflow.